### PR TITLE
Non existent endpoints

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -57,4 +57,12 @@ describe("non-existent endpoints", () => {
             expect(msg).toBe("Requested endpoint does not exist")
         })
     })
+    test("POST 404: returns a Not Found error message", () => {
+        return request(app)
+        .post("/endpoint")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+            expect(msg).toBe("Requested endpoint does not exist")
+        })
+    })
 })

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -73,4 +73,12 @@ describe("non-existent endpoints", () => {
             expect(msg).toBe("Requested endpoint does not exist")
         })
     })
+    test("DELETE 404: returns a Not Found error message", () => {
+        return request(app)
+        .delete("/endpoint")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+            expect(msg).toBe("Requested endpoint does not exist")
+        })
+    })
 })

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -65,4 +65,12 @@ describe("non-existent endpoints", () => {
             expect(msg).toBe("Requested endpoint does not exist")
         })
     })
+    test("PATCH 404: returns a Not Found error message", () => {
+        return request(app)
+        .patch("/endpoint")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+            expect(msg).toBe("Requested endpoint does not exist")
+        })
+    })
 })

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -81,4 +81,12 @@ describe("non-existent endpoints", () => {
             expect(msg).toBe("Requested endpoint does not exist")
         })
     })
+    test("PUT 404: returns a Not Found error message", () => {
+        return request(app)
+        .put("/endpoint")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+            expect(msg).toBe("Requested endpoint does not exist")
+        })
+    })
 })

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -47,3 +47,14 @@ describe("/api", ()=>{
         })
     })
 })
+
+describe("non-existent endpoints", () => {
+    test("GET 404: returns a Not Found error message", () => {
+        return request(app)
+        .get("/endpoint")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+            expect(msg).toBe("Requested endpoint does not exist")
+        })
+    })
+})

--- a/src/error-handlers.ts
+++ b/src/error-handlers.ts
@@ -1,7 +1,11 @@
 import { Response } from "express"
 
+const sendNotFoundError = (res: Response) => {
+    res.status(404).send({msg: "Requested endpoint does not exist"})
+}
+
 const sendMethodNotAllowedError = (res: Response) => {
     res.status(405).send({msg: "Request method not allowed on this endpoint"})
 }
 
-export { sendMethodNotAllowedError }
+export { sendNotFoundError, sendMethodNotAllowedError }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import express, { Express, Request, Response } from 'express'
 import router from './router'
+import { sendNotFoundError } from './error-handlers';
 
 const app: Express = express();
 
 app.use(router)
 
 app.all("*", (req: Request, res: Response) => {
-  res.status(404).send("Not found")
+  sendNotFoundError(res)
 })
 
 export default app


### PR DESCRIPTION
Add tests and functionality for sending 404 errors from non-existent endpoints

Adds sendNotFoundError function to error-handlers.ts