### PR TITLE
Reword query 400

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -674,7 +674,7 @@ describe("/api", () => {
                         expect(exercises).toEqual(orderedExercises)
                     })
                 })
-                test("GET 200: returns a Bad Request error message when sort criteria is invalid", () => {
+                test("GET 400: returns a Bad Request error message when sort criteria is invalid", () => {
                     return request(app)
                     .get("/api/exercises?sort=random")
                     .expect(400)

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -239,7 +239,7 @@ describe("/api", () => {
                     .get("/api/users?sort=random")
                     .expect(400)
                     .then(({body: {msg}}) => {
-                        expect(msg).toBe("Invalid sort criteria")
+                        expect(msg).toBe("Invalid sort query")
                     })
                 })
             })
@@ -354,7 +354,7 @@ describe("/api", () => {
                     .get("/api/users?order=random")
                     .expect(400)
                     .then(({body: {msg}}) => {
-                        expect(msg).toBe("Invalid order criteria")
+                        expect(msg).toBe("Invalid order query")
                     })
                 })
             })
@@ -379,7 +379,7 @@ describe("/api", () => {
                     .get("/api/users?sort=random&order=random")
                     .expect(400)
                     .then(({body: {msg}}) => {
-                        expect(msg).toBe("Invalid sort criteria")
+                        expect(msg).toBe("Invalid sort query")
                     })
                 })
             })
@@ -679,7 +679,7 @@ describe("/api", () => {
                     .get("/api/exercises?sort=random")
                     .expect(400)
                     .then(({body: {msg}}) => {
-                        expect(msg).toBe("Invalid sort criteria")
+                        expect(msg).toBe("Invalid sort query")
                     })
                 })
             })
@@ -827,7 +827,7 @@ describe("/api", () => {
                     .get("/api/exercises?sort=random&order=random")
                     .expect(400)
                     .then(({body: {msg}}) => {
-                        expect(msg).toEqual("Invalid sort criteria")
+                        expect(msg).toEqual("Invalid sort query")
                     })
                 })
             })

--- a/src/controllers/exercises.controllers.ts
+++ b/src/controllers/exercises.controllers.ts
@@ -15,7 +15,7 @@ export const getAllExercises = async (req: Request, res: Response) => {
     const isInvalidSort = !validSortCriteria.includes(sort)
 
     if (isInvalidSort) {
-        sendBadRequestError(res, "Invalid sort criteria")
+        sendBadRequestError(res, "Invalid sort query")
         return
     }
 

--- a/src/controllers/users.controllers.ts
+++ b/src/controllers/users.controllers.ts
@@ -20,11 +20,11 @@ export const getAllUsers = async (req: Request, res: Response) => {
         return
     }
     if (isInvalidSortCriteria) {
-        sendBadRequestError(res, "Invalid sort criteria")
+        sendBadRequestError(res, "Invalid sort query")
         return
     }
     if (isInvalidOrderCriteria) {
-        sendBadRequestError(res, "Invalid order criteria")
+        sendBadRequestError(res, "Invalid order query")
         return
     }
     const sortedUsers = sortUsers(users, sort, order)


### PR DESCRIPTION
Rewords Bad Request error messages sent for queries to say "Invalid <query> query" instead of "Invalid <query> criteria"