### PR TITLE
Conflict tests

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -633,24 +633,24 @@ describe("/api", () => {
                     expect(msg).toBe("Request body should only include name, description, and icon")
                 })
             })
-            test("POST 400: returns a Bad Request error message when given a duplicate exercise name", () => {
+            test("POST 409: returns a Conflict error message when given a duplicate exercise name", () => {
                 const exerciseObject = { name: "Treadmill", description: "description", icon: "icon"}
 
                 return request(app)
                 .post("/api/exercises")
                 .send(exerciseObject)
-                .expect(400)
+                .expect(409)
                 .then(({body: {msg}}) => {
                     expect(msg).toBe("An exercise already exists with that name")
                 })
             })
-            test("POST 400: returns a Bad Request error message when given a duplicate exercise name with different casing", () => {
+            test("POST 409: returns a Conflict error message when given a duplicate exercise name with different casing", () => {
                 const exerciseObject = { name: "treadmill", description: "description", icon: "icon"}
 
                 return request(app)
                 .post("/api/exercises")
                 .send(exerciseObject)
-                .expect(400)
+                .expect(409)
                 .then(({body: {msg}}) => {
                     expect(msg).toBe("An exercise already exists with that name")
                 })

--- a/src/controllers/exercises.controllers.ts
+++ b/src/controllers/exercises.controllers.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { insertExercise, selectAllExercises } from "../models/exercises.models";
-import { sendBadRequestError, sendInternalServerError } from "../error-handlers";
+import { sendBadRequestError, sendConflictError, sendInternalServerError } from "../error-handlers";
 import { getExerciseErrorMessage, sortExercises } from "../utils/exercise.utils";
 
 export const getAllExercises = async (req: Request, res: Response) => {
@@ -42,7 +42,7 @@ export const postExercise = async (req: Request, res: Response) => {
 
     const exercise = await insertExercise(exerciseInput)
     if (exercise.isDuplicateExercise) {
-        sendBadRequestError(res, "An exercise already exists with that name")
+        sendConflictError(res, "An exercise already exists with that name")
         return
     }
     if (exercise._id === undefined) {


### PR DESCRIPTION
Fixes test for POST /api/exercises request sending a duplicate exercise - to expect status 409

Fix postExercise controller to use sendConflictError for duplicate exercises