### PR TITLE
Test cleanup

### DIFF
--- a/__tests__/api-endpoint.test.ts
+++ b/__tests__/api-endpoint.test.ts
@@ -15,22 +15,6 @@ describe("/api", () => {
                 expect(body).toEqual(expectedEndpoints)
             })
         })
-        test("GET 400: returns a Bad Request error message if query given", () => {
-            return request(app)
-            .get("/api?query=this")
-            .expect(400)
-            .then(({body: {msg}}) => {
-                expect(msg).toBe("Invalid query")
-            })
-        })
-        test("GET 400: returns a Bad Request error message if empty query given", () => {
-            return request(app)
-            .get("/api?query")
-            .expect(400)
-            .then(({body: {msg}}) => {
-                expect(msg).toBe("Invalid query")
-            })
-        })
         test("POST 405: returns a Method Not Allowed error message", () => {
             return request(app)
             .post("/api")
@@ -61,6 +45,24 @@ describe("/api", () => {
             .expect(405)
             .then(({ body : { msg }}) => {
                 expect(msg).toBe("Request method not allowed on this endpoint")
+            })
+        })
+    })
+    describe("?", () => {
+        test("GET 400: returns a Bad Request error message if query given", () => {
+            return request(app)
+            .get("/api?query=this")
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toBe("Invalid query")
+            })
+        })
+        test("GET 400: returns a Bad Request error message if empty query given", () => {
+            return request(app)
+            .get("/api?query")
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toBe("Invalid query")
             })
         })
     })

--- a/__tests__/exercises-endpoint.test.ts
+++ b/__tests__/exercises-endpoint.test.ts
@@ -11,7 +11,7 @@ describe("api/exercises", () => {
             .then(({body: {exercises}}) => {
                 expect(exercises).toHaveLength(6)
 
-                exercises.forEach((exercise: MongoDBExercise[]) => {
+                exercises.forEach((exercise: any) => {
                     expect(exercise).toEqual({
                         _id: expect.any(String),
                         name: expect.any(String),

--- a/__tests__/user-utils.test.ts
+++ b/__tests__/user-utils.test.ts
@@ -1,16 +1,5 @@
-import { Document, WithId } from "mongodb";
-import db from "../connection";
 import { MongoDBUser } from "../src/types";
 import { checkUserOrder, checkUserSort, findInvalidUserQueries, getUserErrorMessage, sortUsers } from "../src/utils/user.utils";
-
-const users: WithId<Document>[] = []
-
-beforeAll(async () => {
-    const usersCluster = (await db).collection("users").find({})
-    for await (const user of usersCluster) {
-        users.push(user)
-    }
-})
 
 describe("getUserErrorMessage", () => {
     it("returns an empty string if provided a valid user object", () => {

--- a/__tests__/users-endpoint.test.ts
+++ b/__tests__/users-endpoint.test.ts
@@ -543,22 +543,22 @@ describe("/api/users", () => {
                 expect(msg).toBe("Request method not allowed on this endpoint")
             })
         })
-        describe("?", () => {
-            test("GET 400: returns a Bad Request error message if passed a query", () => {
-                return request(app)
-                .get("/api/users/aaaaa11111bbbbb22222cccc?query=this")
-                .expect(400)
-                .then(({body: {msg}}) => {
-                    expect(msg).toBe("Invalid query")
-                })
+    })
+    describe("/users/:user_id?", () => {
+        test("GET 400: returns a Bad Request error message if passed a query", () => {
+            return request(app)
+            .get("/api/users/aaaaa11111bbbbb22222cccc?query=this")
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toBe("Invalid query")
             })
-            test("GET 400: returns a Bad Request error message if passed an empty query", () => {
-                return request(app)
-                .get("/api/users/aaaaa11111bbbbb22222cccc?query")
-                .expect(400)
-                .then(({body: {msg}}) => {
-                    expect(msg).toBe("Invalid query")
-                })
+        })
+        test("GET 400: returns a Bad Request error message if passed an empty query", () => {
+            return request(app)
+            .get("/api/users/aaaaa11111bbbbb22222cccc?query")
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toBe("Invalid query")
             })
         })
     })

--- a/__tests__/users-endpoint.test.ts
+++ b/__tests__/users-endpoint.test.ts
@@ -406,6 +406,14 @@ describe("/api/users", () => {
                     expect(msg).toBe("No users found")
                 })
             })
+            test("GET 404: returns a Not Found error message when queried with part of an existing username", () => {
+                return request(app)
+                .get("/api/users?username=gym")
+                .expect(404)
+                .then(({body: {msg}}) => {
+                    expect(msg).toBe("No users found")
+                })
+            })
             test("POST 400: returns a Bad Request error message when using a username query on a post", () => {
                 return request(app)
                 .post("/api/users?username=name")


### PR DESCRIPTION
Removes unnecessary beforeAll from user-utils.test.ts

Fixes type declaration in /exercises GET 200 test as test is verifying elements match type structure:
-from MongoDBExercise to any
-not an array type

Adds test for username query on GET /users request - for query being part of an existing username

Moves query tests for /api into a separate endpoints.json in api-endpoint.test.ts

Moves tests for queries to /users/:user_id into a separate describe block in users-endpoint.test.ts