### PR TITLE
rename describe blocks for /users/:user_id endpoint

### DIFF
--- a/__tests__/users-endpoint.test.ts
+++ b/__tests__/users-endpoint.test.ts
@@ -470,7 +470,7 @@ describe("/api/users", () => {
             })
         })
     })
-    describe("/users/:user_id", () => {
+    describe("/:user_id", () => {
         test("GET 200: returns the correct user when given a valid id", async () => {
             const gymbro = await (await db).collection("users").findOne({username: "gymbro"}) || { _id: "" }
 
@@ -544,7 +544,7 @@ describe("/api/users", () => {
             })
         })
     })
-    describe("/users/:user_id?", () => {
+    describe("/:user_id?", () => {
         test("GET 400: returns a Bad Request error message if passed a query", () => {
             return request(app)
             .get("/api/users/aaaaa11111bbbbb22222cccc?query=this")


### PR DESCRIPTION
Renames decscribe blocks in users-endpoint.test.ts to remove unnecessary /users at the start