### PR TITLE
Refactoring

### DIFF
--- a/__tests__/diaries-endpoint.test.ts
+++ b/__tests__/diaries-endpoint.test.ts
@@ -1218,7 +1218,10 @@ describe("/api/diaries", () => {
             })
         })
     })
-    describe("/:diary_id", () => {
+})
+
+describe("/api/diaries/:diary_id", () => {
+    describe("/", () => {
         test("GET 200: returns the diary with given id", async () => {
             const gymbroTreadmillDiary = await (await db).collection("diaries").findOne({username: "gymbro", exercise: "Treadmill"}) || { _id: "" }
             const diaryID = gymbroTreadmillDiary._id.toString()
@@ -1279,7 +1282,7 @@ describe("/api/diaries", () => {
         test("DELETE 200: deletes a diary with given id, serves no response", async () => {
             const gymbroPullUpDiary = await (await db).collection("diaries").findOne({ username: "gymbro", exercise: "Pull Up"}) || { _id: "" }
             const id = gymbroPullUpDiary._id.toString()
-
+    
             return request(app)
             .delete(`/api/diaries/${id}`)
             .expect(204)
@@ -1289,7 +1292,7 @@ describe("/api/diaries", () => {
         })
         test("DELETE 400: returns a Bad Request error message when id is too short", async () => {
             const shortId = "AAAAA11111BBBBBCCCCC333"
-
+    
             return request(app)
             .delete(`/api/diaries/${shortId}`)
             .expect(400)
@@ -1299,7 +1302,7 @@ describe("/api/diaries", () => {
         })
         test("DELETE 400: returns a Bad Request error message when id is too short", async () => {
             const longId = "AAAAA11111BBBBBCCCCC33333"
-
+    
             return request(app)
             .delete(`/api/diaries/${longId}`)
             .expect(400)
@@ -1309,7 +1312,7 @@ describe("/api/diaries", () => {
         })
         test("DELETE 404: returns a Not Found error message when no diary exists with id", async () => {
             const id = "AAAAA11111BBBBBCCCCC3333"
-
+    
             return request(app)
             .delete(`/api/diaries/${id}`)
             .expect(404)
@@ -1319,10 +1322,10 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed a higher personalBest value", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { personalBest: 12}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1345,10 +1348,10 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed a lower personalBest value above existing logs", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { personalBest: 11}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1371,10 +1374,10 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed a higher goal value", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { goal: 20}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1397,10 +1400,10 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed a lower goal value above existing logs", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { goal: 18}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1423,7 +1426,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed a new log object and all existing logs", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [ 
                 {
@@ -1435,7 +1438,7 @@ describe("/api/diaries", () => {
                     "log": 11
                 }
             ]}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1462,7 +1465,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed a log array without existing logs", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [
                 {
@@ -1470,7 +1473,7 @@ describe("/api/diaries", () => {
                     "log": 11
                 }
             ]}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1501,7 +1504,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed a log with a date matching existing log", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [
                 {
@@ -1509,7 +1512,7 @@ describe("/api/diaries", () => {
                     "log": 10
                 }
             ]}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1540,7 +1543,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed a log above personalBest", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [
                 {
@@ -1548,7 +1551,7 @@ describe("/api/diaries", () => {
                     "log": 12
                 }
             ]}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1583,7 +1586,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed multiple new logs", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [
                 {
@@ -1595,7 +1598,7 @@ describe("/api/diaries", () => {
                     "log": 15
                 }
             ]}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1638,7 +1641,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 200: returns updated diary when passed personalBest, goal, and logs to update", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 personalBest: 20,
@@ -1649,7 +1652,7 @@ describe("/api/diaries", () => {
                     "log": 20
                 }
             ]}
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send(patchObject)
@@ -1696,9 +1699,9 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when sent no body", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .expect(400)
@@ -1708,9 +1711,9 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when sent an empty body", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
-
+    
             return request(app)
             .patch(`/api/diaries/${id}`)
             .send({})
@@ -1721,7 +1724,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a username", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { username: "new username" }
             return request(app)
@@ -1734,7 +1737,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed an exercise", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { exercise: "Chin Up" }
             return request(app)
@@ -1747,7 +1750,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a personalBest below existing logs", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { personalBest: 0 }
             return request(app)
@@ -1760,7 +1763,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a personalBest below a log given on the request body", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 personalBest: 18,
@@ -1777,7 +1780,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a goal below existing logs", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { goal: 0 }
             return request(app)
@@ -1790,7 +1793,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a goal below a log given on the request body", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 goal: 19,
@@ -1807,7 +1810,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a logs is an object", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: { date: "02-09-2024", log: 10 }
@@ -1823,7 +1826,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a logs is a string", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: "log"
@@ -1839,7 +1842,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a logs is a number", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: 10
@@ -1855,7 +1858,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a log in logs array is missing a date", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: [{ log: 20 }]
@@ -1871,7 +1874,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a log with date as a number", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: [{ date: 20, log: 15 }]
@@ -1887,7 +1890,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a log with date as an object", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: [{ date: { day: "02-09-2024"}, log: 15 }]
@@ -1903,7 +1906,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a log with date as an array", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: [{ date: ["02-09-2024"], log: 15}]
@@ -1919,7 +1922,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a log in logs array is missing a log property", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: [{ date: "02-09-2024" }]
@@ -1935,7 +1938,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a log with a string log property", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: [{ date: "02-09-2024", log: "15" }]
@@ -1951,7 +1954,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a log with log property being an array", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: [{ date: "02-09-2024", log: ["15"] }]
@@ -1967,7 +1970,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a log with log property being an object", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 logs: [{ date: "02-09-2024", log: { value: "15" } }]
@@ -1983,7 +1986,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a personalBest string", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { personalBest: "10" }
             
@@ -1997,7 +2000,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a personalBest array", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { personalBest: [10] }
             
@@ -2011,7 +2014,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed an personalBest object", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { personalBest: {value: 10} }
             
@@ -2025,7 +2028,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a goal string", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { goal: "15" }
             
@@ -2039,7 +2042,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a goal array", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { goal: [15] }
             
@@ -2053,7 +2056,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a goal object", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { goal: { value: 15 } }
             
@@ -2067,7 +2070,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed an date uses letters", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "XX-XX-XXXX", log: 15 }] }
             
@@ -2081,7 +2084,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a date does not use dashes", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "01/01/2024", log: 15 }] }
             
@@ -2095,7 +2098,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a date that is too long", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "02-09-2024-00:00am", log: 15 }] }
             
@@ -2109,7 +2112,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a date with 00 for day", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "00-09-2024", log: 15 }] }
             
@@ -2123,7 +2126,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a date with day above 31", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "32-09-2024", log: 15 }] }
             
@@ -2137,7 +2140,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a date with 00 for month", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "01-00-2024", log: 15 }] }
             
@@ -2151,7 +2154,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a date with month above 12", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "01-13-2024", log: 15 }] }
             
@@ -2165,7 +2168,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a date with year before 2024", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "31-12-2023", log: 15 }] }
             
@@ -2179,7 +2182,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message when passed a day of 31 in a month with fewer days", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { logs: [{ date: "30-02-2024", log: 15 }] }
             
@@ -2193,9 +2196,9 @@ describe("/api/diaries", () => {
         })
         test("POST 405: returns a Method Not Allowed error message", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
-
+    
             return request(app)
             .post(`/api/diaries/${id}`)
             .expect(405)
@@ -2205,9 +2208,9 @@ describe("/api/diaries", () => {
         })
         test("PUT 405: returns a Method Not Allowed error message", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
-
+    
             return request(app)
             .put(`/api/diaries/${id}`)
             .expect(405)
@@ -2216,10 +2219,10 @@ describe("/api/diaries", () => {
             })
         })
     })
-    describe("/:diary_id?", () => {
+    describe("?", () => {
         test("GET 400: returns a Bad Request error message if passed a query", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             
             return request(app)
@@ -2231,7 +2234,7 @@ describe("/api/diaries", () => {
         })
         test("GET 400: returns a Bad Request error message if passed an empty query", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             
             return request(app)
@@ -2243,7 +2246,7 @@ describe("/api/diaries", () => {
         })
         test("DELETE 400: returns a Bad Request error message if passed a query", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             
             return request(app)
@@ -2255,7 +2258,7 @@ describe("/api/diaries", () => {
         })
         test("DELETE 400: returns a Bad Request error message if passed an empty query", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             
             return request(app)
@@ -2267,7 +2270,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message if passed a query", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             
             return request(app)
@@ -2279,7 +2282,7 @@ describe("/api/diaries", () => {
         })
         test("PATCH 400: returns a Bad Request error message if passed an empty query", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
-
+    
             const id = liftqueenRowingDiary._id.toString()
             
             return request(app)

--- a/__tests__/diary-utils.test.ts
+++ b/__tests__/diary-utils.test.ts
@@ -1,4 +1,4 @@
-import { checkDiaryOrder, checkDiaryQueries, checkDiarySort, formatPatchObject, getDiaryError, generateDiaryPatchError } from "../src/utils/diary.utils"
+import { checkDiaryOrder, checkDiaryQueries, checkDiarySort, formatPatchObject, getDiaryError, getDiaryPatchError } from "../src/utils/diary.utils"
 
 describe("getDiaryError", () => {
     it("returns an empty string for a valid diary object", () => {
@@ -658,22 +658,22 @@ describe("formatPatchObject", () => {
     })
 })
 
-describe("generateDiaryPatchError", () => {
+describe("getDiaryPatchError", () => {
     it("returns an error message when passed an object with no keys", () => {
         const input = {}
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("No request body given")
     })
     it("returns an error message when passed an object with an exercise property", () => {
         const input = { exercise: "Rowing Machine" }
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Request should not provide an exercise")
     })
     it("returns an error message when passed an object with a username property", () => {
         const input = { username: "gymbro" }
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Request should not provide a username")
     })
@@ -685,7 +685,7 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("PersonalBest cannot be below a log")
     })
@@ -697,28 +697,28 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Goal cannot be below a log")
     })
     it("returns an error message when a logs is an object", () => {
         const input = { logs: { date: "02-09-2024", log: 10 } }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Logs must be an array")
     })
     it("returns an error message when a logs is a string", () => {
         const input = { logs: "log" }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Logs must be an array")
     })
     it("returns an error message when a logs is a number", () => {
         const input = { logs: 10 }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Logs must be an array")
     })
@@ -729,7 +729,7 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Logs must have a date")
     })
@@ -740,7 +740,7 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Dates must be a string")
     })
@@ -751,7 +751,7 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Dates must be a string")
     })
@@ -762,7 +762,7 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Dates must be a string")
     })
@@ -773,7 +773,7 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Logs must have a log property")
     })
@@ -784,7 +784,7 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Log must be a number")
     })
@@ -795,7 +795,7 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Log must be a number")
     })
@@ -806,112 +806,112 @@ describe("generateDiaryPatchError", () => {
             ]
         }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Log must be a number")
     })
     it("returns an error message when personalBest is a string", () => {
         const input = { personalBest: "10" }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("PersonalBest must be a number")
     })
     it("returns an error message when personalBest is an array", () => {
         const input = { personalBest: [10] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("PersonalBest must be a number")
     })
     it("returns an error message when personalBest is an object", () => {
         const input = { personalBest: {value: 10} }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("PersonalBest must be a number")
     })
     it("returns an error message when goal is a string", () => {
         const input = { goal: "15" }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Goal must be a number")
     })
     it("returns an error message when goal is an array", () => {
         const input = { goal: [15] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Goal must be a number")
     })
     it("returns an error message when goal is an object", () => {
         const input = { goal: {value: 15} }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Goal must be a number")
     })
     it("returns an error message when a date has letters", () => {
         const input = { logs: [{ date: "XX-XX-XXXX", log: 15}] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Dates must be formatted DD-MM-YYYY")
     })
     it("returns an error message when a date does not use dashes", () => {
         const input = { logs: [{ date: "01/01/2024", log: 15}] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Dates must be formatted DD-MM-YYYY")
     })
     it("returns an error message when a date is too long", () => {
         const input = { logs: [{date: "02-09-2024-00:00am", log: 15 }] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Dates must be formatted DD-MM-YYYY")
     })
     it("returns an error message when a date has day 00", () => {
         const input = { logs: [{date: "00-09-2024", log: 15 }] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Invalid date")
     })
     it("returns an error message when a date has day above 31", () => {
         const input = { logs: [{date: "32-09-2024", log: 15 }] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Invalid date")
     })
     it("returns an error message when a date has month 00", () => {
         const input = { logs: [{date: "01-00-2024", log: 15 }] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Invalid date")
     })
     it("returns an error message when a date has month above 12", () => {
         const input = { logs: [{date: "01-13-2024", log: 15 }] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Invalid date")
     })
     it("returns an error message when a date has year before 2024", () => {
         const input = { logs: [{date: "01-12-2023", log: 15 }] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Invalid date")
     })
     it("returns an error message when a date with day 30 does not exist", () => {
         const input = { logs: [{date: "30-02-2024", log: 15 }] }
 
-        const output = generateDiaryPatchError(input)
+        const output = getDiaryPatchError(input)
 
         expect(output).toBe("Invalid date")
     })

--- a/__tests__/diary-utils.test.ts
+++ b/__tests__/diary-utils.test.ts
@@ -1,6 +1,6 @@
-import { checkDiaryOrder, checkDiaryQueries, checkDiarySort, formatPatchObject, generateDiaryErrorMessage, generateDiaryPatchError } from "../src/utils/diary.utils"
+import { checkDiaryOrder, checkDiaryQueries, checkDiarySort, formatPatchObject, getDiaryError, generateDiaryPatchError } from "../src/utils/diary.utils"
 
-describe("generateDiaryErrorMessage", () => {
+describe("getDiaryError", () => {
     it("returns an empty string for a valid diary object", () => {
         const input = {
             username: "gymbro",
@@ -10,7 +10,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("")
     })
@@ -22,7 +22,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("No username given")
     })
@@ -35,7 +35,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("No username given")
     })
@@ -48,7 +48,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Username must be a string")
     })
@@ -61,7 +61,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Username must be a string")
     })
@@ -74,7 +74,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Username must be a string")
     })
@@ -86,7 +86,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("No exercise given")
     })
@@ -99,7 +99,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("No exercise given")
     })
@@ -112,7 +112,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Exercise must be a string")
     })
@@ -125,7 +125,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Exercise must be a string")
     })
@@ -138,7 +138,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Exercise must be a string")
     })
@@ -151,7 +151,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("PersonalBest must be a number")
     })
@@ -164,7 +164,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("PersonalBest must be a number")
     })
@@ -177,7 +177,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("PersonalBest must be a number")
     })
@@ -190,7 +190,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Goal must be a number")
     })
@@ -203,7 +203,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Goal must be a number")
     })
@@ -216,7 +216,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: []
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Goal must be a number")
     })
@@ -229,7 +229,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: "string"
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -242,7 +242,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: 1
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -255,7 +255,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: {date: "20-01-2024", log: 20}
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -268,7 +268,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: ["string"]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -281,7 +281,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [1]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -294,7 +294,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [[{date: "20-01-2024", log: 20}]]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -307,7 +307,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{log: 20}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -320,7 +320,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: 1, log: 20}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -333,7 +333,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: ["20-01-2024"], log: 20}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -346,7 +346,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: {day: "20-01-2024"}, log: 20}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -359,7 +359,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: "", log: 20}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -372,7 +372,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: "XX-XX-XXXX", log: 20}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -385,7 +385,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: "20-01-2024"}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -398,7 +398,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: "20-01-2024", log: "two"}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -411,7 +411,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: "20-01-2024", log: [2, 2]}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })
@@ -424,7 +424,7 @@ describe("generateDiaryErrorMessage", () => {
             logs: [{date: "20-01-2024", log: {value: 2}}]
         }
 
-        const output = generateDiaryErrorMessage(input)
+        const output = getDiaryError(input)
 
         expect(output).toBe("Logs must be an array of log objects")
     })

--- a/__tests__/exercise-utils.test.ts
+++ b/__tests__/exercise-utils.test.ts
@@ -161,7 +161,6 @@ describe("getExerciseError", () => {
 
         expect(output).toBe("Request body should only include name, description, and icon")
     })
-    // no test for exercise being an object, as this will be req.body
 })
 
 describe("sortExercises", () => {

--- a/__tests__/exercise-utils.test.ts
+++ b/__tests__/exercise-utils.test.ts
@@ -1,6 +1,6 @@
 import { Document, WithId } from "mongodb";
 import db from "../connection";
-import { checkExerciseOrder, checkExerciseSort, findInvalidExerciseQueries, getExerciseErrorMessage, sortExercises } from "../src/utils/exercise.utils";
+import { checkExerciseOrder, checkExerciseSort, findInvalidExerciseQueries, getExerciseError, sortExercises } from "../src/utils/exercise.utils";
 
 const exercises: WithId<Document>[] = []
 
@@ -11,7 +11,7 @@ beforeAll( async () => {
     }
 })
 
-describe("getExerciseErrorMessage", () => {
+describe("getExerciseError", () => {
     it("returns an empty string for a valid exercise object", () => {
         const input = { 
             name: "exercise name",
@@ -19,13 +19,13 @@ describe("getExerciseErrorMessage", () => {
             icon: "filename"
         }
 
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("")
     })
     it("returns correct error message when given an empty object", () => {
         const input = {}
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("No request body given")
     })
@@ -34,7 +34,7 @@ describe("getExerciseErrorMessage", () => {
             description: "description",
             icon: "filename"
         }
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("No name given")
     })
@@ -43,7 +43,7 @@ describe("getExerciseErrorMessage", () => {
             name: "exercise name",
             icon: "filename"
         }
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("No description given")
     })
@@ -52,13 +52,13 @@ describe("getExerciseErrorMessage", () => {
             name: "exercise name",
             description: "description",
         }
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("No icon given")
     })
     it("returns correct error message when exercise missing multiple properties", () => {
         const input = { icon: "file" }
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("No name given")
     })
@@ -68,7 +68,7 @@ describe("getExerciseErrorMessage", () => {
             description: "description",
             icon: "filename"
         }
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("No name given")
     })
@@ -78,7 +78,7 @@ describe("getExerciseErrorMessage", () => {
             description: "",
             icon: "filename"
         }
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("No description given")
     })
@@ -88,7 +88,7 @@ describe("getExerciseErrorMessage", () => {
             description: "description",
             icon: ""
         }
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("No icon given")
     })
@@ -97,13 +97,13 @@ describe("getExerciseErrorMessage", () => {
         const icon = "icon"
 
         const numberName = { name : 1, description, icon }
-        const numberOutput = getExerciseErrorMessage(numberName)
+        const numberOutput = getExerciseError(numberName)
 
         const arrayName = { name: [], description, icon }
-        const arrayOutput = getExerciseErrorMessage(arrayName)
+        const arrayOutput = getExerciseError(arrayName)
         
         const objectName = { name: {}, description, icon }
-        const objectOutput = getExerciseErrorMessage(objectName)
+        const objectOutput = getExerciseError(objectName)
 
         const expectedOutput = "Name must be a string"
 
@@ -116,13 +116,13 @@ describe("getExerciseErrorMessage", () => {
         const icon = "icon"
 
         const numberDescription = { name, description: 1, icon }
-        const numberOutput = getExerciseErrorMessage(numberDescription)
+        const numberOutput = getExerciseError(numberDescription)
 
         const arrayDescription = { name, description: [], icon }
-        const arrayOutput = getExerciseErrorMessage(arrayDescription)
+        const arrayOutput = getExerciseError(arrayDescription)
         
         const objectDescription = { name, description: {}, icon }
-        const objectOutput = getExerciseErrorMessage(objectDescription)
+        const objectOutput = getExerciseError(objectDescription)
 
         const expectedOutput = "Description must be a string"
 
@@ -135,13 +135,13 @@ describe("getExerciseErrorMessage", () => {
         const description = "description"
 
         const numberIcon = { name, description, icon: 1}
-        const numberOutput = getExerciseErrorMessage(numberIcon)
+        const numberOutput = getExerciseError(numberIcon)
 
         const arrayIcon = { name, description, icon: []}
-        const arrayOutput = getExerciseErrorMessage(arrayIcon)
+        const arrayOutput = getExerciseError(arrayIcon)
         
         const objectIcon = { name, description, icon: {}}
-        const objectOutput = getExerciseErrorMessage(objectIcon)
+        const objectOutput = getExerciseError(objectIcon)
 
         const expectedOutput = "Icon must be a string"
 
@@ -157,7 +157,7 @@ describe("getExerciseErrorMessage", () => {
             extraProperty: "value"
         }
 
-        const output = getExerciseErrorMessage(input)
+        const output = getExerciseError(input)
 
         expect(output).toBe("Request body should only include name, description, and icon")
     })

--- a/__tests__/user-utils.test.ts
+++ b/__tests__/user-utils.test.ts
@@ -50,7 +50,6 @@ describe("getUserError", () => {
 
         expect(output).toBe("Request body should only provide a username")
     })
-    // no need for a test checking user is an object, as this is req.body
 })
 
 describe("sortUsers", () => {

--- a/__tests__/user-utils.test.ts
+++ b/__tests__/user-utils.test.ts
@@ -1,52 +1,52 @@
 import { MongoDBUser } from "../src/types";
-import { checkUserOrder, checkUserSort, findInvalidUserQueries, getUserErrorMessage, sortUsers } from "../src/utils/user.utils";
+import { checkUserOrder, checkUserSort, findInvalidUserQueries, getUserError, sortUsers } from "../src/utils/user.utils";
 
-describe("getUserErrorMessage", () => {
+describe("getUserError", () => {
     it("returns an empty string if provided a valid user object", () => {
         const user = { username: "Jeff"}
         
-        const output = getUserErrorMessage(user)
+        const output = getUserError(user)
 
         expect(output).toBe("")
     })
     it("returns correct error message if user object is empty", () => {
         const user = {}
         
-        const output = getUserErrorMessage(user)
+        const output = getUserError(user)
 
         expect(output).toBe("No request body given")
     })
     it("returns correct error message if user object has no username", () => {
         const user = { key: "value"}
         
-        const output = getUserErrorMessage(user)
+        const output = getUserError(user)
 
         expect(output).toBe("No username given")
     })
     it("returns correct error message if username is an empty string", () => {
         const user = { username: ""}
         
-        const output = getUserErrorMessage(user)
+        const output = getUserError(user)
 
         expect(output).toBe("No username given")
     })
     it("returns correct error message if username is not a string", () => {
         const numberUsername = { username: 3}
-        const numberUsernameOutput = getUserErrorMessage(numberUsername)
+        const numberUsernameOutput = getUserError(numberUsername)
         expect(numberUsernameOutput).toBe("Username must be a string")
 
         const arrayUsername = { username: ["username"]}
-        const arrayUsernameOutput = getUserErrorMessage(arrayUsername)
+        const arrayUsernameOutput = getUserError(arrayUsername)
         expect(arrayUsernameOutput).toBe("Username must be a string")
 
         const objectUsername = { username: {username: "username"}}
-        const objectUsernameOutput = getUserErrorMessage(objectUsername)
+        const objectUsernameOutput = getUserError(objectUsername)
         expect(objectUsernameOutput).toBe("Username must be a string")
     })
     it("returns correct error message if user object has extra properties", () => {
         const user = { username: "Jeff", age: 22}
         
-        const output = getUserErrorMessage(user)
+        const output = getUserError(user)
 
         expect(output).toBe("Request body should only provide a username")
     })

--- a/__tests__/users-endpoint.test.ts
+++ b/__tests__/users-endpoint.test.ts
@@ -478,10 +478,13 @@ describe("/api/users", () => {
             })
         })
     })
-    describe("/:user_id", () => {
+})
+
+describe("/api/users/:user_id", () => {
+    describe("/", () => {
         test("GET 200: returns the correct user when given a valid id", async () => {
             const gymbro = await (await db).collection("users").findOne({username: "gymbro"}) || { _id: "" }
-
+    
             return request(app)
             .get(`/api/users/${gymbro._id.toString()}`)
             .expect(200)
@@ -552,7 +555,7 @@ describe("/api/users", () => {
             })
         })
     })
-    describe("/:user_id?", () => {
+    describe("?", () => {
         test("GET 400: returns a Bad Request error message if passed a query", () => {
             return request(app)
             .get("/api/users/aaaaa11111bbbbb22222cccc?query=this")

--- a/__tests__/users-endpoint.test.ts
+++ b/__tests__/users-endpoint.test.ts
@@ -87,7 +87,7 @@ describe("/api/users", () => {
             })
         })
         test("POST 409: returns a Conflict error message if username already exists", () => {
-            const duplicateUser = { username: "gymbro" } // exists in seed data
+            const duplicateUser = { username: "gymbro" }
             
             return request(app)
             .post("/api/users")

--- a/src/controllers/api.controllers.ts
+++ b/src/controllers/api.controllers.ts
@@ -6,14 +6,12 @@ export const getEndpoints = async (req: Request, res: Response) => {
     const isQuery = Object.keys(req.query).length !== 0
 
     if (isQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
 
     const endpoints = selectEndpoints()
     if (endpoints === "") {
-        sendInternalServerError(res, "Error fetching endpoints")
-        return
+        return sendInternalServerError(res, "Error fetching endpoints")
     }
     res.send({ endpoints })
 }

--- a/src/controllers/diaries.controllers.ts
+++ b/src/controllers/diaries.controllers.ts
@@ -1,7 +1,7 @@
 import { Response, Request } from "express"
 import { findDuplicateDiary, insertDiary, removeDiary, selectAllDiaries, selectDiaryById, updateDiary } from "../models/diaries.models"
 import { sendBadRequestError, sendConflictError, sendInternalServerError, sendInvalidOrderError, sendInvalidQueryError, sendInvalidSortError, sendNotFoundError } from "../error-handlers"
-import { checkDiaryOrder, checkDiaryQueries, checkDiarySort, formatPatchObject, getDiaryError, generateDiaryPatchError } from "../utils/diary.utils"
+import { checkDiaryOrder, checkDiaryQueries, checkDiarySort, formatPatchObject, getDiaryError, getDiaryPatchError } from "../utils/diary.utils"
 import { selectUserByUsername } from "../models/users.models"
 import { selectExerciseByName } from "../models/exercises.models"
 import { MongoDBDiary } from "../types"
@@ -246,7 +246,7 @@ export const patchDiary = async (req: Request, res: Response) => {
 
     const body = req.body
 
-    const error = generateDiaryPatchError(body)
+    const error = getDiaryPatchError(body)
 
     if (error) {
         sendBadRequestError(res, error)

--- a/src/controllers/diaries.controllers.ts
+++ b/src/controllers/diaries.controllers.ts
@@ -136,6 +136,7 @@ export const postDiary = async (req: Request, res: Response) => {
     }
     if (isValidUsername.isError) {
         sendInternalServerError(res, "Error posting diary")
+        return
     }
 
     const isValidExercise = await selectExerciseByName(exercise)
@@ -230,6 +231,7 @@ export const deleteDiary = async (req: Request, res: Response) => {
     const deletedDiary = await removeDiary(id)
     if (deletedDiary.isError || deletedDiary.deleted === false) {
         sendInternalServerError(res, "Error deleting diary")
+        return
     }
     res.status(204).send()
 }

--- a/src/controllers/diaries.controllers.ts
+++ b/src/controllers/diaries.controllers.ts
@@ -12,70 +12,58 @@ export const getAllDiaries = async (req: Request, res: Response) => {
     
     const isInvalidQuery = checkDiaryQueries(queries)
     if (isInvalidQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
     
     const { sort, order, username, exercise } = req.query
 
     const isInvalidSort = checkDiarySort(sort)
     if (isInvalidSort) {
-        sendInvalidSortError(res)
-        return
+        return sendInvalidSortError(res)
     }
 
     const isInvalidOrder = checkDiaryOrder(order)
     if (isInvalidOrder) {
-        sendInvalidOrderError(res)
-        return
+        return sendInvalidOrderError(res)
     }
 
     if (username === "") {
-        sendBadRequestError(res, "No username given")
-        return
+        return sendBadRequestError(res, "No username given")
     }
 
     if (username) {
         if (Array.isArray(username)) {
-            sendBadRequestError(res, "Multiple username queries given")
-            return
+            return sendBadRequestError(res, "Multiple username queries given")
         } 
         const user = await selectUserByUsername(username)
         if (!user) {
-            sendNotFoundError(res, "Username not found")
-            return
+            return sendNotFoundError(res, "Username not found")
         }
         if (user.isError) {
-            sendInternalServerError(res, "Error fetching diaries")
-            return
+            return sendInternalServerError(res, "Error fetching diaries")
         }
     }
     
     if (exercise === "") {
-        sendBadRequestError(res, "No exercise given")
-        return
+        return sendBadRequestError(res, "No exercise given")
     }
 
     if (exercise) {
         if (Array.isArray(exercise)) {
-            sendBadRequestError(res, "Multiple exercise queries given")
-            return
+            return sendBadRequestError(res, "Multiple exercise queries given")
         }
         const isExercise = await selectExerciseByName(exercise)
         if (!isExercise) {
-            sendNotFoundError(res, "Exercise not found")
-            return
+            return sendNotFoundError(res, "Exercise not found")     
         }
         if (isExercise.isError) {
-            sendInternalServerError(res, "Error fetching diaries")
-            return
+            return sendInternalServerError(res, "Error fetching diaries")
         }
     }
 
     let diaries: any = await selectAllDiaries()
     if (diaries.isError) {
-        sendInternalServerError(res, "Error fetching diaries")
-        return
+        return sendInternalServerError(res, "Error fetching diaries")
     }
 
     if (sort === "username" || sort === "exercise") {
@@ -105,8 +93,7 @@ export const getAllDiaries = async (req: Request, res: Response) => {
     }
 
     if (diaries.length === 0) {
-        sendNotFoundError(res, "No diaries found")
-        return
+        return sendNotFoundError(res, "No diaries found")
     }
 
     res.send({ diaries })
@@ -115,55 +102,47 @@ export const getAllDiaries = async (req: Request, res: Response) => {
 export const postDiary = async (req: Request, res: Response) => {
     const isQuery = Object.keys(req.query).length !== 0
     if (isQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
 
     const diaryObject = req.body
 
     const diaryError = getDiaryError(diaryObject)
     if (diaryError) {
-        sendBadRequestError(res, diaryError)
-        return
+        return sendBadRequestError(res, diaryError)
     }
 
     const { username, exercise } = diaryObject
     const isValidUsername = await selectUserByUsername(username)
 
     if (!isValidUsername) {
-        sendBadRequestError(res, "No user exists with given username")
-        return
+        return sendBadRequestError(res, "No user exists with given username")
     }
     if (isValidUsername.isError) {
-        sendInternalServerError(res, "Error posting diary")
-        return
+        return sendInternalServerError(res, "Error posting diary")
     }
 
     const isValidExercise = await selectExerciseByName(exercise)
     if (!isValidExercise) {
-        sendBadRequestError(res, "Exercise does not exist")
-        return
+        return sendBadRequestError(res, "Exercise does not exist")
     }
     if (isValidExercise.isError) {
-        sendInternalServerError(res, "Error posting diary")
-        return
+        return sendInternalServerError(res, "Error posting diary")
     }
 
     const isDiaryDuplicate = await findDuplicateDiary(username, exercise)
     if (isDiaryDuplicate && isDiaryDuplicate.isError) {
-        sendInternalServerError(res, "Error posting diary")
-        return
+        return sendInternalServerError(res, "Error posting diary")
     }
     if (isDiaryDuplicate) {
-        sendConflictError(res, "Diary already exists")
-        return
+        return sendConflictError(res, "Diary already exists")
+        
     }
 
     const diary = await insertDiary(diaryObject)
 
     if (diary.isError) {
-        sendInternalServerError(res, "Error posting diary")
-        return
+        return sendInternalServerError(res, "Error posting diary")
     }
 
     res.status(201).send({diary})
@@ -172,8 +151,7 @@ export const postDiary = async (req: Request, res: Response) => {
 export const getDiaryById = async (req: Request, res: Response) => {
     const isQuery = Object.keys(req.query).length
     if (isQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
 
     const givenId = req.params.diary_id
@@ -183,18 +161,15 @@ export const getDiaryById = async (req: Request, res: Response) => {
         id = new ObjectId(givenId)
     }
     catch {
-        sendBadRequestError(res, "Invalid diary id")
-        return
+        return sendBadRequestError(res, "Invalid diary id")
     }
     
     const diary = await selectDiaryById(id)
     if (!diary) {
-        sendNotFoundError(res, "Diary not found")
-        return
+        return sendNotFoundError(res, "Diary not found")
     }
     if (diary.isError) {
-        sendInternalServerError(res, "Error fetching diary")
-        return
+        return sendInternalServerError(res, "Error fetching diary")
     }
 
     res.send({ diary })
@@ -203,8 +178,7 @@ export const getDiaryById = async (req: Request, res: Response) => {
 export const deleteDiary = async (req: Request, res: Response) => {
     const isQuery = Object.keys(req.query).length
     if (isQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
 
     const givenId = req.params.diary_id
@@ -214,24 +188,20 @@ export const deleteDiary = async (req: Request, res: Response) => {
         id = new ObjectId(givenId)
     }
     catch {
-        sendBadRequestError(res, "Invalid diary id")
-        return
+        return sendBadRequestError(res, "Invalid diary id")
     }
     
     const isIdValid: any = await selectDiaryById(id)
     if (!isIdValid) {
-        sendNotFoundError(res, "Diary not found")
-        return
+        return sendNotFoundError(res, "Diary not found")
     }
     if (isIdValid.isError) {
-        sendInternalServerError(res, "Error deleting diary")
-        return
+        return sendInternalServerError(res, "Error deleting diary")
     }
 
     const deletedDiary = await removeDiary(id)
     if (deletedDiary.isError || deletedDiary.deleted === false) {
-        sendInternalServerError(res, "Error deleting diary")
-        return
+        return sendInternalServerError(res, "Error deleting diary")
     }
     res.status(204).send()
 }
@@ -239,8 +209,7 @@ export const deleteDiary = async (req: Request, res: Response) => {
 export const patchDiary = async (req: Request, res: Response) => {
     const isQuery = Object.keys(req.query).length
     if (isQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
     
     const givenId = req.params.diary_id
@@ -251,8 +220,7 @@ export const patchDiary = async (req: Request, res: Response) => {
     const error = getDiaryPatchError(body)
 
     if (error) {
-        sendBadRequestError(res, error)
-        return
+        return sendBadRequestError(res, error)
     }
 
     const {logs, personalBest, goal} = body
@@ -261,12 +229,10 @@ export const patchDiary = async (req: Request, res: Response) => {
 
     const highestDiaryLog = Math.max(...diaryToPatch.logs.map((log:any)=>log.log)) 
     if (personalBest < highestDiaryLog) {
-        sendBadRequestError(res, "PersonalBest cannot be below a log")
-        return
+        return sendBadRequestError(res, "PersonalBest cannot be below a log")
     }
     if (goal < highestDiaryLog) {
-        sendBadRequestError(res, "Goal cannot be below a log")
-        return
+        return sendBadRequestError(res, "Goal cannot be below a log")
     }
 
     let highestPatchLog = 0
@@ -286,8 +252,7 @@ export const patchDiary = async (req: Request, res: Response) => {
 
     const updateAttempt = await updateDiary(id, patchObject)
     if (!updateAttempt.success || updateAttempt.isError) {
-        sendInternalServerError(res, "Error patching diary")
-        return
+        return sendInternalServerError(res, "Error patching diary")
     }
 
     const updatedDiary = await selectDiaryById(id)

--- a/src/controllers/diaries.controllers.ts
+++ b/src/controllers/diaries.controllers.ts
@@ -1,7 +1,7 @@
 import { Response, Request } from "express"
 import { findDuplicateDiary, insertDiary, removeDiary, selectAllDiaries, selectDiaryById, updateDiary } from "../models/diaries.models"
 import { sendBadRequestError, sendConflictError, sendInternalServerError, sendInvalidOrderError, sendInvalidQueryError, sendInvalidSortError, sendNotFoundError } from "../error-handlers"
-import { checkDiaryOrder, checkDiaryQueries, checkDiarySort, formatPatchObject, generateDiaryErrorMessage, generateDiaryPatchError } from "../utils/diary.utils"
+import { checkDiaryOrder, checkDiaryQueries, checkDiarySort, formatPatchObject, getDiaryError, generateDiaryPatchError } from "../utils/diary.utils"
 import { selectUserByUsername } from "../models/users.models"
 import { selectExerciseByName } from "../models/exercises.models"
 import { MongoDBDiary } from "../types"
@@ -121,7 +121,7 @@ export const postDiary = async (req: Request, res: Response) => {
 
     const diaryObject = req.body
 
-    const diaryError = generateDiaryErrorMessage(diaryObject)
+    const diaryError = getDiaryError(diaryObject)
     if (diaryError) {
         sendBadRequestError(res, diaryError)
         return

--- a/src/controllers/exercises.controllers.ts
+++ b/src/controllers/exercises.controllers.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { insertExercise, selectAllExercises, selectExerciseByName } from "../models/exercises.models";
 import { sendBadRequestError, sendConflictError, sendInternalServerError, sendInvalidQueryError, sendInvalidSortError, sendNotFoundError } from "../error-handlers";
-import { checkExerciseOrder, checkExerciseSort, findInvalidExerciseQueries, getExerciseErrorMessage, sortExercises } from "../utils/exercise.utils";
+import { checkExerciseOrder, checkExerciseSort, findInvalidExerciseQueries, getExerciseError, sortExercises } from "../utils/exercise.utils";
 
 export const getAllExercises = async (req: Request, res: Response) => {
     const queries = Object.keys(req.query)
@@ -57,7 +57,7 @@ export const postExercise = async (req: Request, res: Response) => {
     }
     const exerciseInput = req.body
 
-    const exerciseError = getExerciseErrorMessage(exerciseInput)
+    const exerciseError = getExerciseError(exerciseInput)
     if (exerciseError) {
         sendBadRequestError(res, exerciseError)
         return

--- a/src/controllers/exercises.controllers.ts
+++ b/src/controllers/exercises.controllers.ts
@@ -7,42 +7,35 @@ export const getAllExercises = async (req: Request, res: Response) => {
     const queries = Object.keys(req.query)
     const isInvalidQuery = findInvalidExerciseQueries(queries)
     if (isInvalidQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
 
     const { name, sort, order } = req.query
     
     if (Array.isArray(name)) {
-        sendBadRequestError(res, "Multiple name queries given")
-        return  
+        return sendBadRequestError(res, "Multiple name queries given")
     }
     if (name === "") {
-        sendBadRequestError(res, "No name given")
-        return
+        return sendBadRequestError(res, "No name given")
     }
     if (typeof name === "string") {
-        getExerciseByName(res, name)
-        return
+        return getExerciseByName(res, name)
     }
 
     const isInvalidSort = checkExerciseSort(sort)
     if (isInvalidSort) {
-        sendInvalidSortError(res)
-        return
+        return sendInvalidSortError(res)
     }
 
     const isInvalidOrder = checkExerciseOrder(order)
     if (isInvalidOrder) {
-        sendBadRequestError(res, "Invalid order query")
-        return
+        return sendBadRequestError(res, "Invalid order query")
     }
 
     const exercises = await selectAllExercises()
     const isError = exercises.length === 0
     if (isError) {
-        sendInternalServerError(res, "Error fetching exercises")
-        return
+        return sendInternalServerError(res, "Error fetching exercises")
     }
 
     const sortedExercises = sortExercises(exercises, sort, order)
@@ -52,25 +45,21 @@ export const getAllExercises = async (req: Request, res: Response) => {
 export const postExercise = async (req: Request, res: Response) => {
     const isQuery = Object.keys(req.query).length !== 0
     if (isQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
     const exerciseInput = req.body
 
     const exerciseError = getExerciseError(exerciseInput)
     if (exerciseError) {
-        sendBadRequestError(res, exerciseError)
-        return
+        return sendBadRequestError(res, exerciseError)
     }
 
     const exercise = await insertExercise(exerciseInput)
     if (exercise.isDuplicateExercise) {
-        sendConflictError(res, "An exercise already exists with that name")
-        return
+        return sendConflictError(res, "An exercise already exists with that name")
     }
     if (exercise._id === undefined) {
-        sendInternalServerError(res, "Error posting exercise")
-        return
+        return sendInternalServerError(res, "Error posting exercise")
     }
     res.status(201).send({exercise})
 }
@@ -78,12 +67,10 @@ export const postExercise = async (req: Request, res: Response) => {
 const getExerciseByName = async (res: Response, name: string) => {
     const exercise: any = await selectExerciseByName(name)
     if (exercise === null) {
-        sendNotFoundError(res, "No exercises found")
-        return
+        return sendNotFoundError(res, "No exercises found")
     }
     if (exercise.isError) {
-        sendInternalServerError(res, "Error fetching exercises")
-        return
+        return sendInternalServerError(res, "Error fetching exercises")
     }
     res.send({exercises: [exercise]})
 }

--- a/src/controllers/users.controllers.ts
+++ b/src/controllers/users.controllers.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express"
 import { insertUser, selectAllUsers, selectUserById, selectUserByUsername } from "../models/users.models"
 import { sendBadRequestError, sendConflictError, sendInternalServerError, sendInvalidQueryError, sendInvalidSortError, sendNotFoundError } from "../error-handlers"
-import { checkUserOrder, checkUserSort, findInvalidUserQueries, getUserErrorMessage, sortUsers } from "../utils/user.utils"
+import { checkUserOrder, checkUserSort, findInvalidUserQueries, getUserError, sortUsers } from "../utils/user.utils"
 import { ObjectId } from "mongodb"
 
 export const getAllUsers = async (req: Request, res: Response) => {
@@ -59,7 +59,7 @@ export const postUser = async (req: Request, res: Response) => {
     }
 
     const userObject = req.body
-    const userErrorMessage = getUserErrorMessage(userObject) // returns empty string if no error, else provides error message
+    const userErrorMessage = getUserError(userObject) // returns empty string if no error, else provides error message
 
     if (userErrorMessage) {
         sendBadRequestError(res, userErrorMessage)

--- a/src/controllers/users.controllers.ts
+++ b/src/controllers/users.controllers.ts
@@ -51,7 +51,7 @@ export const postUser = async (req: Request, res: Response) => {
     }
 
     const userObject = req.body
-    const userErrorMessage = getUserError(userObject) // returns empty string if no error, else provides error message
+    const userErrorMessage = getUserError(userObject)
 
     if (userErrorMessage) {
         return sendBadRequestError(res, userErrorMessage)

--- a/src/controllers/users.controllers.ts
+++ b/src/controllers/users.controllers.ts
@@ -8,44 +8,37 @@ export const getAllUsers = async (req: Request, res: Response) => {
     const queries = Object.keys(req.query)
     const isInvalidQuery = findInvalidUserQueries(queries)
     if (isInvalidQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
 
     const { sort, order, username } = req.query
     
     const isInvalidSort = checkUserSort(sort)
     if (isInvalidSort) {
-        sendInvalidSortError(res)
-        return
+        return sendInvalidSortError(res)
     }
 
     const isInvalidOrder = checkUserOrder(order)
     if (isInvalidOrder) {
-        sendBadRequestError(res, "Invalid order query")
-        return
+        return sendBadRequestError(res, "Invalid order query")
     }
     
     if (Array.isArray(username)) {
-        sendBadRequestError(res, "Multiple username queries given")
-        return
+        return sendBadRequestError(res, "Multiple username queries given")
     }
 
     if (username === "") {
-        sendBadRequestError(res, "No username given")
-        return
+        return sendBadRequestError(res, "No username given")
     }
     if (username) {
-        getUserByUsername(res, username)
-        return
+        return getUserByUsername(res, username)
     }
 
     const users = await selectAllUsers()
 
     const isServerError = users.length === 0
     if (isServerError) {
-        sendInternalServerError(res, "Error fetching users")
-        return
+        return sendInternalServerError(res, "Error fetching users")
     }
     const sortedUsers = sortUsers(users, sort, order)
     res.send({ users: sortedUsers })
@@ -54,26 +47,22 @@ export const getAllUsers = async (req: Request, res: Response) => {
 export const postUser = async (req: Request, res: Response) => {
     const isQuery = Object.keys(req.query).length !== 0
     if (isQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
 
     const userObject = req.body
     const userErrorMessage = getUserError(userObject) // returns empty string if no error, else provides error message
 
     if (userErrorMessage) {
-        sendBadRequestError(res, userErrorMessage)
-        return
+        return sendBadRequestError(res, userErrorMessage)
     }
 
     const user = await insertUser(userObject)    
     if (user.isDuplicateUser) {
-        sendConflictError(res, "A user already exists with given username")
-        return 
+        return sendConflictError(res, "A user already exists with given username")
     }
     if (user._id === undefined) {
-        sendInternalServerError(res, "Error posting user")
-        return
+        return sendInternalServerError(res, "Error posting user")
     }
     res.status(201).send({ user })
 }
@@ -81,8 +70,7 @@ export const postUser = async (req: Request, res: Response) => {
 export const getUserById = async (req: Request, res: Response) => {
     const isQuery = Object.keys(req.query).length !== 0
     if (isQuery) {
-        sendInvalidQueryError(res)
-        return
+        return sendInvalidQueryError(res)
     }
 
     const { user_id } = req.params
@@ -92,18 +80,15 @@ export const getUserById = async (req: Request, res: Response) => {
         id = new ObjectId(user_id)
     }
     catch {
-        sendBadRequestError(res, "Invalid user id")
-        return
+        return sendBadRequestError(res, "Invalid user id")
     }
     
     const user: any = await selectUserById(id)
     if (user === null) {
-        sendNotFoundError(res, "User not found")
-        return
+        return sendNotFoundError(res, "User not found")
     }
     if (user.isError) {
-        sendInternalServerError(res, "Error fetching user")
-        return
+        return sendInternalServerError(res, "Error fetching user")
     }
     
     delete user._id
@@ -113,15 +98,12 @@ export const getUserById = async (req: Request, res: Response) => {
 const getUserByUsername = async (res: Response, username: any) => {
     const user = await selectUserByUsername(username)
     if (user === null) {
-        sendNotFoundError(res, "No users found")
-        return
+        return sendNotFoundError(res, "No users found")
     }
     if (user.isError) {
-        sendInternalServerError(res, "Error fetching users")
-        return
+        return sendInternalServerError(res, "Error fetching users")
     }
 
     delete user.exercises
     res.send({users: [user]})
-    return
 }

--- a/src/controllers/users.controllers.ts
+++ b/src/controllers/users.controllers.ts
@@ -51,10 +51,10 @@ export const postUser = async (req: Request, res: Response) => {
     }
 
     const userObject = req.body
-    const userErrorMessage = getUserError(userObject)
+    const userError = getUserError(userObject)
 
-    if (userErrorMessage) {
-        return sendBadRequestError(res, userErrorMessage)
+    if (userError) {
+        return sendBadRequestError(res, userError)
     }
 
     const user = await insertUser(userObject)    

--- a/src/models/exercises.models.ts
+++ b/src/models/exercises.models.ts
@@ -38,6 +38,7 @@ export const insertExercise = async (exercise: Exercise) => {
 }
 
 const findExercise = async (exercise: Exercise) => {
+    // try catch not used as error will be caught in insertExercise
     const exerciseRegex = new RegExp(`^${exercise.name}$`, "i") // case insensitive exercise name
     const matchingExercise = await (await db).collection("exercises").findOne({ name: exerciseRegex })
     return matchingExercise

--- a/src/utils/diary.utils.ts
+++ b/src/utils/diary.utils.ts
@@ -83,7 +83,7 @@ export const formatPatchObject = (patchObject: any) => {
     return { $set : patchObject }
 }
 
-export const generateDiaryPatchError = (patchBody: any): string => {
+export const getDiaryPatchError = (patchBody: any): string => {
     const properties = Object.keys(patchBody)
 
     const isEmptyBody = properties.length === 0

--- a/src/utils/diary.utils.ts
+++ b/src/utils/diary.utils.ts
@@ -1,6 +1,6 @@
 import { Log } from "../types"
 
-export const generateDiaryErrorMessage = (diary: any): string => {
+export const getDiaryError = (diary: any): string => {
     const {username, exercise, personalBest, goal, logs } = diary
     
     if (username === "" || username === undefined) {

--- a/src/utils/exercise.utils.ts
+++ b/src/utils/exercise.utils.ts
@@ -1,4 +1,4 @@
-export const getExerciseErrorMessage = (exercise: any): string => {
+export const getExerciseError = (exercise: any): string => {
     const numberOfProperties = Object.keys(exercise).length
     const { name, description, icon } = exercise
     

--- a/src/utils/exercise.utils.ts
+++ b/src/utils/exercise.utils.ts
@@ -6,7 +6,6 @@ export const getExerciseError = (exercise: any): string => {
         return "No request body given"
     }
 
-    // checks for missing properties, returned error message states first missing property found
     if (!name) {
         return "No name given"
     }

--- a/src/utils/user.utils.ts
+++ b/src/utils/user.utils.ts
@@ -1,4 +1,4 @@
-export const getUserErrorMessage = (user: any): string => {
+export const getUserError = (user: any): string => {
     const {username} = user
     const userProperties = Object.keys(user).length
 


### PR DESCRIPTION
Reorganises endpoint testing file describe blocks

Renames utils functions with names to have "get" instead of "generate", and "Error" instead of "ErrorMessage"

Adds missing return statements in controllers for caught MongoDB errors

Reorganises return statements to a single line in all controllers 

Removes unnecessary comments

Adds comment to findExercise model to explain lack of try/catch blocks 