### PR TITLE
Add log units

### DIFF
--- a/__tests__/diaries-endpoint.test.ts
+++ b/__tests__/diaries-endpoint.test.ts
@@ -23,7 +23,8 @@ describe("/api/diaries", () => {
                     diary.logs.forEach((element: any) => {
                         expect(element).toEqual({
                             date: expect.stringMatching(/\d\d-\d\d-\d\d\d\d/),
-                            log: expect.any(Number)
+                            log: expect.any(Number),
+                            units: expect.any(String)
                         })
                     })
                 })
@@ -532,7 +533,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{log: 20 }]
+                logs: [{log: 20, units: "kg" }]
             }
 
             return request(app)
@@ -549,7 +550,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: 10, log: 20 }]
+                logs: [{date: 10, log: 20, units: "kg" }]
             }
 
             return request(app)
@@ -566,7 +567,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: ["20-01-2024", "21-01-2024"], log: 20 }]
+                logs: [{date: ["20-01-2024", "21-01-2024"], log: 20, units: "kg" }]
             }
 
             return request(app)
@@ -583,7 +584,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: {day: "20-01-2024"}, log: 20 }]
+                logs: [{date: {day: "20-01-2024"}, log: 20, units: "kg" }]
             }
 
             return request(app)
@@ -600,7 +601,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: "", log: 20 }]
+                logs: [{date: "", log: 20, units: "kg" }]
             }
 
             return request(app)
@@ -617,7 +618,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: "XX-XX-XXXX", log: 20 }]
+                logs: [{date: "XX-XX-XXXX", log: 20, units: "kg" }]
             }
 
             return request(app)
@@ -634,7 +635,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: "20-01-2024"}]
+                logs: [{date: "20-01-2024", units: "kg"}]
             }
 
             return request(app)
@@ -651,7 +652,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: "20-01-2024", log: "two"}]
+                logs: [{date: "20-01-2024", log: "two", units: "kg"}]
             }
 
             return request(app)
@@ -668,7 +669,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: "20-01-2024", log: [2, 3]}]
+                logs: [{date: "20-01-2024", log: [2, 3], units: "kg"}]
             }
 
             return request(app)
@@ -685,7 +686,7 @@ describe("/api/diaries", () => {
                 exercise: "Leg Press",
                 personalBest: 20,
                 goal: 40,
-                logs: [{date: "20-01-2024", log: {value: 2}}]
+                logs: [{date: "20-01-2024", log: {value: 2}, units: "kg"}]
             }
 
             return request(app)
@@ -705,11 +706,13 @@ describe("/api/diaries", () => {
                 logs: [
                     {
                         date: "26-08-2024",
-                        log: 10
+                        log: 10,
+                        units: "mins"
                     },
                     {
                         date: "28-08-2024",
-                        log: 15
+                        log: 15, 
+                        units: "mins"
                     }
                 ]
             }
@@ -1239,11 +1242,13 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [
                         {
                             "date": "20-08-2024",
-                            "log": 10
+                            "log": 10, 
+                            "units": "km"
                         },
                         {
                             "date": "22-08-2024",
-                            "log": 10
+                            "log": 10, 
+                            "units": "km"
                         }
                     ]
                 })
@@ -1340,7 +1345,8 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1366,7 +1372,8 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1392,7 +1399,8 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1418,7 +1426,8 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10, 
+                            "units": "km"
                         }
                     ]
                 })
@@ -1431,11 +1440,13 @@ describe("/api/diaries/:diary_id", () => {
             const patchObject = { logs: [ 
                 {
                     "date": "26-08-2024",
-                    "log": 10
+                    "log": 10,
+                    "units": "km"
                 },
                 {
                     "date": "27-08-2024",
-                    "log": 11
+                    "log": 11,
+                    "units": "km"
                 }
             ]}
     
@@ -1453,11 +1464,13 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "27-08-2024",
-                            "log": 11
+                            "log": 11,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1470,7 +1483,8 @@ describe("/api/diaries/:diary_id", () => {
             const patchObject = { logs: [
                 {
                     "date": "28-08-2024",
-                    "log": 11
+                    "log": 11,
+                    "units": "km"
                 }
             ]}
     
@@ -1488,15 +1502,18 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "27-08-2024",
-                            "log": 11
+                            "log": 11,
+                            "units": "km"
                         },
                         {
                             "date": "28-08-2024",
-                            "log": 11
+                            "log": 11,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1509,7 +1526,8 @@ describe("/api/diaries/:diary_id", () => {
             const patchObject = { logs: [
                 {
                     "date": "28-08-2024",
-                    "log": 10
+                    "log": 10,
+                    "units": "km"
                 }
             ]}
     
@@ -1527,15 +1545,18 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "27-08-2024",
-                            "log": 11
+                            "log": 11,
+                            "units": "km"
                         },
                         {
                             "date": "28-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1548,7 +1569,8 @@ describe("/api/diaries/:diary_id", () => {
             const patchObject = { logs: [
                 {
                     "date": "29-08-2024",
-                    "log": 12
+                    "log": 12,
+                    "units": "km"
                 }
             ]}
     
@@ -1566,19 +1588,23 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "27-08-2024",
-                            "log": 11
+                            "log": 11,
+                            "units": "km"
                         },
                         {
                             "date": "28-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "29-08-2024",
-                            "log": 12
+                            "log": 12,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1591,11 +1617,13 @@ describe("/api/diaries/:diary_id", () => {
             const patchObject = { logs: [
                 {
                     "date": "30-09-2024",
-                    "log": 16
+                    "log": 16,
+                    "units": "km"
                 },
                 {
                     "date": "01-09-2024",
-                    "log": 15
+                    "log": 15,
+                    "units": "km"
                 }
             ]}
     
@@ -1613,27 +1641,33 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "27-08-2024",
-                            "log": 11
+                            "log": 11,
+                            "units": "km"
                         },
                         {
                             "date": "28-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "29-08-2024",
-                            "log": 12
+                            "log": 12,
+                            "units": "km"
                         },
                         {
                             "date": "30-09-2024",
-                            "log": 16
+                            "log": 16,
+                            "units": "km"
                         },
                         {
                             "date": "01-09-2024",
-                            "log": 15
+                            "log": 15,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1649,7 +1683,8 @@ describe("/api/diaries/:diary_id", () => {
                 logs: [
                 {
                     "date": "02-09-2024",
-                    "log": 20
+                    "log": 20,
+                    "units": "km"
                 }
             ]}
     
@@ -1667,31 +1702,38 @@ describe("/api/diaries/:diary_id", () => {
                     logs: [ 
                         {
                             "date": "26-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "27-08-2024",
-                            "log": 11
+                            "log": 11,
+                            "units": "km"
                         },
                         {
                             "date": "28-08-2024",
-                            "log": 10
+                            "log": 10,
+                            "units": "km"
                         },
                         {
                             "date": "29-08-2024",
-                            "log": 12
+                            "log": 12,
+                            "units": "km"
                         },
                         {
                             "date": "30-09-2024",
-                            "log": 16
+                            "log": 16,
+                            "units": "km"
                         },
                         {
                             "date": "01-09-2024",
-                            "log": 15
+                            "log": 15,
+                            "units": "km"
                         },
                         {
                             "date": "02-09-2024",
-                            "log": 20
+                            "log": 20,
+                            "units": "km"
                         }
                     ]
                 })
@@ -1767,7 +1809,7 @@ describe("/api/diaries/:diary_id", () => {
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 personalBest: 18,
-                logs: [{ date: "02-09-2024", log: 20 }]
+                logs: [{ date: "02-09-2024", log: 20, units: "km" }]
             }
             
             return request(app)
@@ -1797,7 +1839,7 @@ describe("/api/diaries/:diary_id", () => {
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
                 goal: 19,
-                logs: [{ date: "02-09-2024", log: 20 }]
+                logs: [{ date: "02-09-2024", log: 20, units: "km" }]
             }
             
             return request(app)
@@ -1808,12 +1850,12 @@ describe("/api/diaries/:diary_id", () => {
                 expect(msg).toBe("Goal cannot be below a log")
             })
         })
-        test("PATCH 400: returns a Bad Request error message when passed a logs is an object", async () => {
+        test("PATCH 400: returns a Bad Request error message when passed a log object", async () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
-                logs: { date: "02-09-2024", log: 10 }
+                logs: { date: "02-09-2024", log: 10, units: "km" }
             }
             
             return request(app)
@@ -1893,7 +1935,7 @@ describe("/api/diaries/:diary_id", () => {
     
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
-                logs: [{ date: { day: "02-09-2024"}, log: 15 }]
+                logs: [{ date: { day: "02-09-2024"}, log: 15, units: "km" }]
             }
             
             return request(app)
@@ -1909,7 +1951,7 @@ describe("/api/diaries/:diary_id", () => {
     
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
-                logs: [{ date: ["02-09-2024"], log: 15}]
+                logs: [{ date: ["02-09-2024"], log: 15, units: "km"}]
             }
             
             return request(app)
@@ -1925,7 +1967,7 @@ describe("/api/diaries/:diary_id", () => {
     
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
-                logs: [{ date: "02-09-2024" }]
+                logs: [{ date: "02-09-2024", units: "km" }]
             }
             
             return request(app)
@@ -1941,7 +1983,7 @@ describe("/api/diaries/:diary_id", () => {
     
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
-                logs: [{ date: "02-09-2024", log: "15" }]
+                logs: [{ date: "02-09-2024", log: "15", units: "km" }]
             }
             
             return request(app)
@@ -1957,7 +1999,7 @@ describe("/api/diaries/:diary_id", () => {
     
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
-                logs: [{ date: "02-09-2024", log: ["15"] }]
+                logs: [{ date: "02-09-2024", log: ["15"], units: "km" }]
             }
             
             return request(app)
@@ -1973,7 +2015,7 @@ describe("/api/diaries/:diary_id", () => {
     
             const id = liftqueenRowingDiary._id.toString()
             const patchObject = { 
-                logs: [{ date: "02-09-2024", log: { value: "15" } }]
+                logs: [{ date: "02-09-2024", log: { value: "15" }, units: "km" }]
             }
             
             return request(app)
@@ -2072,7 +2114,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "XX-XX-XXXX", log: 15 }] }
+            const patchObject = { logs: [{ date: "XX-XX-XXXX", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)
@@ -2086,7 +2128,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "01/01/2024", log: 15 }] }
+            const patchObject = { logs: [{ date: "01/01/2024", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)
@@ -2100,7 +2142,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "02-09-2024-00:00am", log: 15 }] }
+            const patchObject = { logs: [{ date: "02-09-2024-00:00am", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)
@@ -2114,7 +2156,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "00-09-2024", log: 15 }] }
+            const patchObject = { logs: [{ date: "00-09-2024", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)
@@ -2128,7 +2170,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "32-09-2024", log: 15 }] }
+            const patchObject = { logs: [{ date: "32-09-2024", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)
@@ -2142,7 +2184,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "01-00-2024", log: 15 }] }
+            const patchObject = { logs: [{ date: "01-00-2024", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)
@@ -2156,7 +2198,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "01-13-2024", log: 15 }] }
+            const patchObject = { logs: [{ date: "01-13-2024", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)
@@ -2170,7 +2212,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "31-12-2023", log: 15 }] }
+            const patchObject = { logs: [{ date: "31-12-2023", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)
@@ -2184,7 +2226,7 @@ describe("/api/diaries/:diary_id", () => {
             const liftqueenRowingDiary = await (await db).collection("diaries").findOne({ username: "liftqueen", exercise: "Rowing Machine"}) || { _id: "" }
     
             const id = liftqueenRowingDiary._id.toString()
-            const patchObject = { logs: [{ date: "30-02-2024", log: 15 }] }
+            const patchObject = { logs: [{ date: "30-02-2024", log: 15, units: "km" }] }
             
             return request(app)
             .patch(`/api/diaries/${id}`)

--- a/__tests__/diaries-endpoint.test.ts
+++ b/__tests__/diaries-endpoint.test.ts
@@ -733,6 +733,108 @@ describe("/api/diaries", () => {
                 expect(msg).toEqual("Logs must be an array of log objects")
             })
         })
+        test("POST 400: returns a Bad Request error message when logs array has no units property", () => {
+            const diary = {
+                username: "gymbro",
+                exercise: "Leg Press",
+                personalBest: 20,
+                goal: 40,
+                logs: [{ date: "25-01-2024", log: 10 }]
+            }
+
+            return request(app)
+            .post("/api/diaries")
+            .send(diary)
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toEqual("Logs must be an array of log objects")
+            })
+        })
+        test("POST 400: returns a Bad Request error message when logs array has a number units property", () => {
+            const diary = {
+                username: "gymbro",
+                exercise: "Leg Press",
+                personalBest: 20,
+                goal: 40,
+                logs: [{ date: "25-01-2024", log: 10, units: 1 }]
+            }
+
+            return request(app)
+            .post("/api/diaries")
+            .send(diary)
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toEqual("Logs must be an array of log objects")
+            })
+        })
+        test("POST 400: returns a Bad Request error message when logs array has an array units property", () => {
+            const diary = {
+                username: "gymbro",
+                exercise: "Leg Press",
+                personalBest: 20,
+                goal: 40,
+                logs: [{ date: "25-01-2024", log: 10, units: ["kg"] }]
+            }
+
+            return request(app)
+            .post("/api/diaries")
+            .send(diary)
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toEqual("Logs must be an array of log objects")
+            })
+        })
+        test("POST 400: returns a Bad Request error message when logs array has an object units property", () => {
+            const diary = {
+                username: "gymbro",
+                exercise: "Leg Press",
+                personalBest: 20,
+                goal: 40,
+                logs: [{ date: "25-01-2024", log: 10, units: { unit: "kg"} }]
+            }
+
+            return request(app)
+            .post("/api/diaries")
+            .send(diary)
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toEqual("Logs must be an array of log objects")
+            })
+        })
+        test("POST 400: returns a Bad Request error message when logs array has an empty string units property", () => {
+            const diary = {
+                username: "gymbro",
+                exercise: "Leg Press",
+                personalBest: 20,
+                goal: 40,
+                logs: [{ date: "25-01-2024", log: 10, units: "" }]
+            }
+
+            return request(app)
+            .post("/api/diaries")
+            .send(diary)
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toEqual("Logs must be an array of log objects")
+            })
+        })
+        test("POST 400: returns a Bad Request error message when logs array has an invalid units property", () => {
+            const diary = {
+                username: "gymbro",
+                exercise: "Leg Press",
+                personalBest: 20,
+                goal: 40,
+                logs: [{ date: "25-01-2024", log: 10, units: "unit" }]
+            }
+
+            return request(app)
+            .post("/api/diaries")
+            .send(diary)
+            .expect(400)
+            .then(({body: {msg}}) => {
+                expect(msg).toEqual("Logs must be an array of log objects")
+            })
+        })
         test("POST 409: returns a Conflict error message when existing diary exists for username and exercise", () => {
             const diary = {
                 username: "liftqueen",

--- a/__tests__/diaries-endpoint.test.ts
+++ b/__tests__/diaries-endpoint.test.ts
@@ -30,7 +30,7 @@ describe("/api/diaries", () => {
                 })
             })
         })
-        test("POST 201: returns the posted diary object", () => {
+        test("POST 201: returns the posted diary object when given an empty log array", () => {
             const diary = {
                 username: "gymbro",
                 exercise: "Leg Press",
@@ -74,6 +74,42 @@ describe("/api/diaries", () => {
                     personalBest: 22.5,
                     goal: 40,
                     logs: []
+                })
+            })
+        })
+        test("POST 201: returns the posted diary object when given a populated log array", () => {
+            const diary = {
+                username: "legituser",
+                exercise: "Treadmill",
+                personalBest: 22.5,
+                goal: 40,
+                logs: [
+                    {
+                        date: "02-11-2024",
+                        log: 10,
+                        units: "km"
+                    }
+                ]
+            }
+
+            return request(app)
+            .post("/api/diaries")
+            .send(diary)
+            .expect(201)
+            .then(({body: {diary}}) => {
+                expect(diary).toEqual({
+                    _id: expect.any(String),
+                    username: "legituser",
+                    exercise: "Treadmill",
+                    personalBest: 22.5,
+                    goal: 40,
+                    logs: [
+                        {
+                            date: "02-11-2024",
+                            log: 10,
+                            units: "km"
+                        }
+                    ]
                 })
             })
         })

--- a/__tests__/diary-utils.test.ts
+++ b/__tests__/diary-utils.test.ts
@@ -7,7 +7,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: []
+            logs: [{ date: "05-01-2024", log: 10, units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -304,7 +304,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{log: 20}]
+            logs: [{log: 20, units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -317,7 +317,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: 1, log: 20}]
+            logs: [{date: 1, log: 20, units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -330,7 +330,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: ["20-01-2024"], log: 20}]
+            logs: [{date: ["20-01-2024"], log: 20, units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -343,7 +343,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: {day: "20-01-2024"}, log: 20}]
+            logs: [{date: {day: "20-01-2024"}, log: 20, units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -356,7 +356,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: "", log: 20}]
+            logs: [{date: "", log: 20, units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -369,7 +369,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: "XX-XX-XXXX", log: 20}]
+            logs: [{date: "XX-XX-XXXX", log: 20, units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -382,7 +382,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: "20-01-2024"}]
+            logs: [{date: "20-01-2024", units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -395,7 +395,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: "20-01-2024", log: "two"}]
+            logs: [{date: "20-01-2024", log: "two", units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -408,7 +408,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: "20-01-2024", log: [2, 2]}]
+            logs: [{date: "20-01-2024", log: [2, 2], units: "kg"}]
         }
 
         const output = getDiaryError(input)
@@ -421,7 +421,7 @@ describe("getDiaryError", () => {
             exercise: "Leg Press",
             personalBest: 2,
             goal: 4,
-            logs: [{date: "20-01-2024", log: {value: 2}}]
+            logs: [{date: "20-01-2024", log: {value: 2}, units: "kg"}]
         }
 
         const output = getDiaryError(input)

--- a/__tests__/diary-utils.test.ts
+++ b/__tests__/diary-utils.test.ts
@@ -506,6 +506,19 @@ describe("getDiaryError", () => {
 
         expect(output).toBe("Logs must be an array of log objects")
     })
+    it("returns correct error string for a diary with an extra property", () => {
+        const input = {
+            username: "gymbro",
+            exercise: "Leg Press",
+            personalBest: 2,
+            goal: 4,
+            logs: [{ date: "05-01-2024", log: 10, units: "kg", extra: "other" }]
+        }
+
+        const output = getDiaryError(input)
+
+        expect(output).toBe("Logs must be an array of log objects")
+    })
 })
 
 describe("checkDiarySort", () => {

--- a/__tests__/diary-utils.test.ts
+++ b/__tests__/diary-utils.test.ts
@@ -428,6 +428,84 @@ describe("getDiaryError", () => {
 
         expect(output).toBe("Logs must be an array of log objects")
     })
+    it("returns correct error string for a diary with missing units property", () => {
+        const input = {
+            username: "gymbro",
+            exercise: "Leg Press",
+            personalBest: 2,
+            goal: 4,
+            logs: [{ date: "05-01-2024", log: 10 }]
+        }
+
+        const output = getDiaryError(input)
+
+        expect(output).toBe("Logs must be an array of log objects")
+    })
+    it("returns correct error string for a diary with a number units property", () => {
+        const input = {
+            username: "gymbro",
+            exercise: "Leg Press",
+            personalBest: 2,
+            goal: 4,
+            logs: [{ date: "05-01-2024", log: 10, units: 1 }]
+        }
+
+        const output = getDiaryError(input)
+
+        expect(output).toBe("Logs must be an array of log objects")
+    })
+    it("returns correct error string for a diary with an array units property", () => {
+        const input = {
+            username: "gymbro",
+            exercise: "Leg Press",
+            personalBest: 2,
+            goal: 4,
+            logs: [{ date: "05-01-2024", log: 10, units: [1] }]
+        }
+
+        const output = getDiaryError(input)
+
+        expect(output).toBe("Logs must be an array of log objects")
+    })
+    it("returns correct error string for a diary with an object units property", () => {
+        const input = {
+            username: "gymbro",
+            exercise: "Leg Press",
+            personalBest: 2,
+            goal: 4,
+            logs: [{ date: "05-01-2024", log: 10, units: {unit: "kg"} }]
+        }
+
+        const output = getDiaryError(input)
+
+        expect(output).toBe("Logs must be an array of log objects")
+    })
+    it("returns correct error string for a diary with an empty string units property", () => {
+        const input = {
+            username: "gymbro",
+            exercise: "Leg Press",
+            personalBest: 2,
+            goal: 4,
+            logs: [{ date: "05-01-2024", log: 10, units: "" }]
+        }
+
+        const output = getDiaryError(input)
+
+        expect(output).toBe("Logs must be an array of log objects")
+    })
+    it("returns correct error string for a diary with an invalid units property", () => {
+        const input = {
+            username: "gymbro",
+            exercise: "Leg Press",
+            personalBest: 2,
+            goal: 4,
+            logs: [{ date: "05-01-2024", log: 10, units: "kgs" }]
+        }
+
+        const output = getDiaryError(input)
+
+        expect(output).toBe("Logs must be an array of log objects")
+    })
 })
 
 describe("checkDiarySort", () => {

--- a/src/controllers/diaries.controllers.ts
+++ b/src/controllers/diaries.controllers.ts
@@ -139,6 +139,10 @@ export const postDiary = async (req: Request, res: Response) => {
         
     }
 
+    if (diaryObject.logs === undefined) {
+        diaryObject.logs = []
+    }
+
     const diary = await insertDiary(diaryObject)
 
     if (diary.isError) {

--- a/src/models/diaries.models.ts
+++ b/src/models/diaries.models.ts
@@ -42,11 +42,10 @@ export const insertDiary = async (diary: Diary) => {
     try {
         const response = await (await db).collection("diaries").insertOne(diary)
         const id = response.insertedId
-    
+
         return {
             _id: id,
-            ...diary,
-            logs: []
+            ...diary
         }
     }
     catch {

--- a/src/seeding/data/development-data/diaries.ts
+++ b/src/seeding/data/development-data/diaries.ts
@@ -6,16 +6,18 @@ module.exports = [
         goal: 50,
         logs: [
             {
-                date: "24-08-2024",
-                log: 27.5
+                log: 27.5,
+                units: "kg"
             },
             {
                 date: "26-08-2024",
-                log: 27.5
+                log: 27.5,
+                units: "kg"
             },
             {
                 date: "29-08-2024",
-                log: 30
+                log: 30,
+                units: "kg"
             }
         ]
     },
@@ -34,11 +36,13 @@ module.exports = [
         logs: [
             {
                 date: "20-08-2024",
-                log: 10
+                log: 10,
+                units: "km"
             },
             {
                 date: "22-08-2024",
-                log: 10
+                log: 10,
+                units: "km"
             }
         ]
     },
@@ -50,7 +54,8 @@ module.exports = [
         logs: [
             {
                 date: "26-08-2024",
-                log: 10
+                log: 10,
+                units: "km"
             }
         ]
     },
@@ -62,11 +67,13 @@ module.exports = [
         logs: [
             {
                 date: "26-08-2024",
-                log: 10
+                log: 10,
+                units: "mins"
             },
             {
                 date: "28-08-2024",
-                log: 15
+                log: 15,
+                units: "mins"
             }
         ]
     },
@@ -77,7 +84,8 @@ module.exports = [
         logs: [
             {
                 date: "29-08-2024",
-                log: 1
+                log: 1,
+                units: "count"
             }
         ]
     },
@@ -88,15 +96,18 @@ module.exports = [
         logs: [
             {
                 date: "08-09-2024",
-                log: 20
+                log: 20,
+                units: "count"
             },
             {
                 date: "09-09-2024",
-                log: 20
+                log: 20,
+                units: "count"
             },
             {
                 date: "10-09-2024",
-                log: 20
+                log: 20,
+                units: "count"
             }
         ]
     },
@@ -108,15 +119,18 @@ module.exports = [
         logs: [
             {
                 date: "08-09-2024",
-                log: 15
+                log: 15,
+                units: "km"
             },
             {
                 date: "09-09-2024",
-                log: 15
+                log: 15,
+                units: "km"
             },
             {
                 date: "10-09-2024",
-                log: 15
+                log: 15,
+                units: "km"
             }
         ]
     },
@@ -127,7 +141,8 @@ module.exports = [
         logs: [
             {
                 date: "11-09-2024",
-                log: 25
+                log: 25,
+                units: "km"
             }
         ]
     },
@@ -138,15 +153,18 @@ module.exports = [
         logs: [
             {
                 date: "11-09-2024",
-                log: 47.5
+                log: 47.5,
+                units: "kg"
             },
             {
                 date: "12-09-2024",
-                log: 47.5
+                log: 47.5,
+                units: "kg"
             },
             {
                 date: "13-09-2024",
-                log: 50
+                log: 50,
+                units: "kg"
             }
         ]
     },

--- a/src/seeding/data/test-data/diaries.ts
+++ b/src/seeding/data/test-data/diaries.ts
@@ -7,15 +7,18 @@ module.exports = [
         logs: [
             {
                 date: "24-08-2024",
-                log: 27.5
+                log: 27.5,
+                units: "kg"
             },
             {
                 date: "26-08-2024",
-                log: 27.5
+                log: 27.5,
+                units: "kg"
             },
             {
                 date: "29-08-2024",
-                log: 30
+                log: 30,
+                units: "kg"
             }
         ]
     },
@@ -34,11 +37,13 @@ module.exports = [
         logs: [
             {
                 date: "20-08-2024",
-                log: 10
+                log: 10,
+                units: "km"
             },
             {
                 date: "22-08-2024",
-                log: 10
+                log: 10,
+                units: "km"
             }
         ]
     },
@@ -50,7 +55,8 @@ module.exports = [
         logs: [
             {
                 date: "26-08-2024",
-                log: 10
+                log: 10,
+                units: "km"
             }
         ]
     },
@@ -62,11 +68,13 @@ module.exports = [
         logs: [
             {
                 date: "26-08-2024",
-                log: 10
+                log: 10,
+                units: "mins"
             },
             {
                 date: "28-08-2024",
-                log: 15
+                log: 15,
+                units: "mins"
             }
         ]
     },
@@ -77,7 +85,8 @@ module.exports = [
         logs: [
             {
                 date: "29-08-2024",
-                log: 1
+                log: 1,
+                units: "count"
             }
         ]
     }

--- a/src/utils/diary.utils.ts
+++ b/src/utils/diary.utils.ts
@@ -37,7 +37,10 @@ export const getDiaryError = (diary: any): string => {
         const isDateValid = typeof element.date === "string" && /\d\d-\d\d-\d\d\d\d/.test(element.date)
 
         const isLogValid = typeof element.log === "number"
-        if (!isDateValid || !isLogValid) {
+
+        const validUnits = ["kg", "lb", "mins", "km", "miles", "count"]
+        const isUnitsValid = typeof element.units === "string" && validUnits.includes(element.units)
+        if (!isDateValid || !isLogValid || !isUnitsValid) {
             return "Logs must be an array of log objects"
         }
     }

--- a/src/utils/diary.utils.ts
+++ b/src/utils/diary.utils.ts
@@ -34,13 +34,15 @@ export const getDiaryError = (diary: any): string => {
         if (!isElementObject) {
             return "Logs must be an array of log objects"
         }
+        const logKeys = Object.keys(element)
+        const hasCorrectKeys = logKeys.length === 3 && logKeys.includes("date") && logKeys.includes("log") && logKeys.includes("units")
         const isDateValid = typeof element.date === "string" && /\d\d-\d\d-\d\d\d\d/.test(element.date)
 
         const isLogValid = typeof element.log === "number"
 
         const validUnits = ["kg", "lb", "mins", "km", "miles", "count"]
         const isUnitsValid = typeof element.units === "string" && validUnits.includes(element.units)
-        if (!isDateValid || !isLogValid || !isUnitsValid) {
+        if (!hasCorrectKeys || !isDateValid || !isLogValid || !isUnitsValid) {
             return "Logs must be an array of log objects"
         }
     }


### PR DESCRIPTION
Updates tests for getDiaryError to include a units property on logs

Adds test for getDiaryError being passed a diary with invalid properties in its logs

Adds tests getDiaryError being passed a diary with invalid units properties

Adds handling of units property on log objects to getDiaryError

Updates tests in diaries-endpoint.test.ts to include a units property on logs

Adds tests to diaries-endpoint.test.ts for invalid units property on logs

Updates postDiary model to use logs array on diary object it is passed

Updates insertDiary controller to add a logs array to diary object if one is not given

Updates seed data to include units property on log objects